### PR TITLE
Improve cleanup commands

### DIFF
--- a/net.blumia.pineapple-pictures.yml
+++ b/net.blumia.pineapple-pictures.yml
@@ -11,6 +11,13 @@ finish-args:
   - --filesystem=host
   - --device=dri
 
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/man
+  
+
 modules:
   - name: inih
     buildsystem: meson


### PR DESCRIPTION
Remove development-related files to reduce the Flatpak size.

```
448K	./include
24K	    ./lib/cmake
16K	    ./lib/pkgconfig
12K	    ./share/man
```

See: https://github.com/flathub-infra/vorarbeiter/actions/runs/23999305626/job/69992662863#step:21:40